### PR TITLE
fixed wrong unit in mouseover for travel honour

### DIFF
--- a/awards/functions.py
+++ b/awards/functions.py
@@ -1168,7 +1168,7 @@ def createAwards(tornAwards, userInfo, typeOfAwards):
                     vp["achieve"] = min(1, daysOfFlight / float(vp["goal"]))
                     ratio = daysOfFlight / daysOld
                     vp["left"] = "{:.1f}".format(max(float(vp["goal"] - daysOfFlight) / ratio, 0.0)) if ratio > 0 else "&infin;"
-                    vp["comment"] = "current ratio of {:.2g} hours / day&#10;current state {:.1f} / {} hours".format(ratio, hoursOfFlight, vp["goal"] * 24)
+                    vp["comment"] = "current ratio of {:.2g} hours / day&#10;current state {:.1f} / {} hours".format(ratio * 24, hoursOfFlight, vp["goal"] * 24)
                     awards[type]["h_" + k] = vp
 
                 elif int(k) in [130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 272]:

--- a/templates/awards/list.html
+++ b/templates/awards/list.html
@@ -175,7 +175,7 @@ This file is part of yata.
                         <span class="awarded-time" title="Awarded on: {{award.awarded_time|ts2date}}" rel="tooltip">{{award.awarded_time|ts2date:"%Y/%m/%d"}}</span>
                     </td>
                 {% else %}
-                    <td class="f {% if award.unreach %}neutral{% else %}award-todo{% endif %}" data-val="{{award.achieve}}"><span title="Acheived: {{award.achieve|mul:100|intdiv:1|floatformat:0}}%" rel="tooltip">{{award.achieve|mul:100|intdiv:1|floatformat:0}}%</span></td>
+                    <td class="f {% if award.unreach %}neutral{% else %}award-todo{% endif %}" data-val="{{award.achieve}}"><span title="Achieved: {{award.achieve|mul:100|intdiv:1|floatformat:0}}%" rel="tooltip">{{award.achieve|mul:100|intdiv:1|floatformat:0}}%</span></td>
                     <td class="g" data-val="{{award.left|convertInf}}">
                         {% if award.left %}
                             <span class="thelp" title="{{award.comment|safe}}" rel="tooltip">{{award.left|float2IfSmall|safe}}</span>


### PR DESCRIPTION
Found another one.
It's currently showing the ratio in "days spent traveling"/day as opposed to "hours spent traveling"/day in the tooltip for travel time honours.