### PR TITLE
Tidied up .env and added documentation to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ Create a local .env file
 
 
     ###### OPTIONAL ######
-    APIKEY="API KEY HERE" # Your TORN API KEY
-    CACHE_RESPONSE=10 # For most leaving this as default should be fine, but if you have any issues with -4 cache responses you may wish to increase this gradually
+    # Your TORN API KEY
+    APIKEY="API KEY HERE" 
+    # For most leaving this as default should be fine, but if you have any issues with -4 cache responses you may wish to increase this gradually
+    CACHE_RESPONSE=10 
 
     # The amount of chain report crontabs to run when running crons manually via python dev_cron.py
     CHAIN_REPORT = 1

--- a/README.md
+++ b/README.md
@@ -20,41 +20,38 @@ The website is hosted here: https://yata.alwaysdata.net/
 
 Create a local .env file
 
-    # Your TORN API KEY
-    APIKEY="TORNAPIKEY"
-
-    # You can leave this as it or specify your own
-    SECRET_KEY="SUPER_SECRET_KEY"
-    DEBUG=1
+    ###### REQUIRED ######
+    DEBUG=True
+    SECRET_KEY="super_secret_key"
     ALLOWED_HOSTS="*"
 
     # Database selection
     DATABASE=sqlite
-    # DATABASE=postgresql
-
-    # PG_NAME=yata
-    # PG_USER=username
-    # PG_PASSWORD=password
-    # PG_HOST=localhost
-    # PG_PORT=5432
+    #DATABASE=postgresql
+    #PG_NAME=yata
+    #PG_USER=username
+    #PG_PASSWORD=password
+    #PG_HOST=localhost
+    #PG_PORT=5432
 
     # REDIS
-    USE_REDIS=0
-    # USE_REDIS=1
-    # REDIS_HOST="redis://127.0.0.1:6379/1"
-    # REDIS_PASSWORD="your password"
+    #USE_REDIS=True
+    #REDIS_HOST="redis://178.62.1.116:6379/1"
+    #REDIS_PASSWORD="x$i#T8sLg&U4u8W3DBc4^G9b3Bv2bFJy08iNt"
 
-    # For most leaving this as default should be fine, but if you have any issues with -4 cache responses you may wish to increase this gradually
-    CACHE_RESPONSE=10
 
-    # The amount of chain report crontabs to run
-    CHAIN_REPORT=1
+    ###### OPTIONAL ######
+    APIKEY="API KEY HERE" # Your TORN API KEY
+    CACHE_RESPONSE=10 # For most leaving this as default should be fine, but if you have any issues with -4 cache responses you may wish to increase this gradually
 
-    # The amount of attack report crontabs to run
-    ATTACK_REPORT=1
+    # The amount of chain report crontabs to run when running crons manually via python dev_cron.py
+    CHAIN_REPORT = 1
 
-    # The amount of revive report crontabs to run
-    REVIVE_REPORT=1
+    # The amount of attack report crontabs to run when running crons manually via python dev_cron.py
+    ATTACK_REPORT = 1
+
+    # The amount of revive report crontabs to run when running crons manually via python dev_cron.py
+    REVIVE_REPORT = 1
 
 Then run setup.py to initalise everything
 

--- a/yata/settings.py
+++ b/yata/settings.py
@@ -20,10 +20,7 @@ PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
 
 # SECURITY WARNING: don't run with debug turned on in production!
-if config('DEBUG') == "1":
-    DEBUG = True
-else:
-    DEBUG = False
+DEBUG = config('DEBUG', default=False, cast=bool)
 print(f"SETTINGS: DEBUG={DEBUG}")
 
 # SECURITY WARNING: keep the secret key used in production secret!
@@ -31,7 +28,7 @@ print(f"SETTINGS: DEBUG={DEBUG}")
 SECRET_KEY = config('SECRET_KEY')
 print(f"SETTINGS: SECRET_KEY={SECRET_KEY}")
 
-ALLOWED_HOSTS = [config('ALLOWED_HOSTS')]
+ALLOWED_HOSTS = [config('ALLOWED_HOSTS', default="*")]
 print(f"SETTINGS: ALLOWED_HOSTS={ALLOWED_HOSTS}")
 
 # Application definition
@@ -100,7 +97,7 @@ WSGI_APPLICATION = 'yata.wsgi.application'
 
 # Database
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases
-if config("DATABASE") == "postgresql":
+if config("DATABASE", default="sqlite", cast=str )== "postgresql":
     print(f"SETTINGS: DATABASE=postgresql")
 
     DATABASES = {
@@ -142,7 +139,7 @@ def get_cache():
     import os
     print(f"SETTINGS: CACHE=redis")
 
-    if (config('USE_REDIS') == "1"):
+    if (config('USE_REDIS', default=False, cast=bool)):
         return {
             'default': {
                 "BACKEND": "django_redis.cache.RedisCache",


### PR DESCRIPTION
Set some defaults so YATA will run without any .env file in the most compatible way it can.
Reorganised recommended .env format
Added extra information around some of the settings
Added documentation for undocumented .env variables