### PR TITLE
Sentry changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ django-json-widget>=1.0.1
 # - development server (./manage.py runserver)
 # - sqlite3 database
 gunicorn>=20.0.4
-psycopg2>=2.8.4  # need to install (sudo apt-get install libpq-dev)
+psycopg2>=2.8.4  # need to install (sudo apt-get install libpq-dev python3-dev)
 # psycopg2-binary>=2.8.4
 django-extensions>=3.0.8
 
@@ -37,4 +37,4 @@ django-brotli>=0.2.0
 whitenoise>=5.2.0
 
 #sentry
-sentry-sdk>=0.19.1
+sentry-sdk

--- a/yata/settings.py
+++ b/yata/settings.py
@@ -236,7 +236,7 @@ if config("ENABLE_SENTRY", default=False, cast=bool):
     sentry_sdk.init(
         dsn=config("SENTRY_DSN"),
         integrations=[DjangoIntegration()],
-        traces_sample_rate=config("SENTRY_SAMPLE_RATE", default=1.0, cast=float),
+        traces_sample_rate=config("SENTRY_SAMPLE_RATE", default=0.0, cast=float),
         environment=config("SENTRY_ENVIRONMENT"),
     )
 else:


### PR DESCRIPTION
Some minor changes to Sentry

If the SENTRY_SAMPLE_RATE is set to 0 yata continues to run even if sentry is down. This should be set in .env

Also updated pre-req for psycopg2

#422 