### PR TITLE
Lock Django version to be compatible with 3.x 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # core modules
-Django>=3.1.2
+Django~=3.1.2
 django-mathfilters>=1.0.0
 requests>=2.22.0
 django-json-widget>=1.0.1


### PR DESCRIPTION
`pip install -r requirements.txt` would grab Django 4.x which isn't compatible with 3.x as YATA uses.
