### PR TITLE
Fixed NNB displayed with company perks

### DIFF
--- a/faction/models.py
+++ b/faction/models.py
@@ -1442,7 +1442,7 @@ class Member(models.Model):
                 nnb = req['nerve'].get('maximum', 0)
 
                 # company perks
-                for p in req.get("company_perks", []):
+                for p in req.get("job_perks", []):
                     sp = p.split(' ')
                     # not python 3.5 compatible
                     # match = re.match(r'([+]){1} (\d){1,2} ([mMaximum]){7} nerve', p)


### PR DESCRIPTION
Fix based on https://www.torn.com/forums.php#/p=threads&f=19&t=16276258&b=0&a=0&to=22426733

Only company perks changed after the above bug report to be merged with job perks and none of the perks should have been renamed. Other issues were likely caused by the lack of perks returned as shown in the above bug report but I was unable to test the code.