### PR TITLE
Fix casing change in merit_perks for NNB

### DIFF
--- a/faction/models.py
+++ b/faction/models.py
@@ -1645,7 +1645,7 @@ class Member(models.Model):
                 # merit perks
                 for p in req.get("merit_perks", []):
                     sp = p.split(' ')
-                    if len(sp) == 4 and sp[3] == "nerve" and sp[2] == "Maximum":
+                    if len(sp) == 4 and sp[3] == "nerve" and sp[2] == "maximum":
                         nnb -= int(sp[1])
 
                 self.nnb = nnb


### PR DESCRIPTION
The API response for user perks changed an entry from merit_perks:
`"+ 10 maximum nerve",`
It used to be "Maximum", which means the nerve merits are not subtracted from the NNB value anymore.

This fixes the NNB problem.