### PR TITLE
hide default admin route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ yata_uwsgi.ini
 yata.sock
 tmp
 debug/faction-keys-*
+**.idea/**

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Create a local .env file
     SECRET_KEY="xxx"
     ALLOWED_HOSTS="*"
     LOG_KEY="xxx"
+    ADMIN_URL_PREFIX="prefix/" # Enter a prefix for your admin URL with a trailing slash.
 
     # Database selection
     DATABASE=sqlite

--- a/templates/header.html
+++ b/templates/header.html
@@ -176,6 +176,15 @@ along with yata. If not, see <https: //www.gnu.org/licenses />.
               </div>
             </li>
 
+            {# admin #}
+            {% if user.is_superuser %}
+            <li class="nav-item">
+              <div class="nav-link yt-main-link">
+                <a href="{% url 'admin:index' %}" title="Admin"><b><i class="fas fa-cog"></i>&nbsp;Admin</b></a>
+              </div>
+            </li>
+            {% endif %}
+
             {# bot #}
             {% comment %} <li class="nav-item">
               <div class="nav-link yt-main-link">

--- a/templates/header.html
+++ b/templates/header.html
@@ -176,15 +176,6 @@ along with yata. If not, see <https: //www.gnu.org/licenses />.
               </div>
             </li>
 
-            {# admin #}
-            {% if user.is_superuser %}
-            <li class="nav-item">
-              <div class="nav-link yt-main-link">
-                <a href="{% url 'admin:index' %}" title="Admin"><b><i class="fas fa-cog"></i>&nbsp;Admin</b></a>
-              </div>
-            </li>
-            {% endif %}
-
             {# bot #}
             {% comment %} <li class="nav-item">
               <div class="nav-link yt-main-link">

--- a/yata/settings.py
+++ b/yata/settings.py
@@ -271,3 +271,7 @@ else:
 
 #  src directory
 SRC_ROOT = os.path.join(PROJECT_ROOT, 'src')
+
+
+# ADMIN URL HASH
+ADMIN_URL_HASH = hash(SECRET_KEY)

--- a/yata/settings.py
+++ b/yata/settings.py
@@ -274,4 +274,6 @@ SRC_ROOT = os.path.join(PROJECT_ROOT, 'src')
 
 
 # ADMIN URL HASH
-ADMIN_URL_HASH = hash(SECRET_KEY)
+ADMIN_URL_PREFIX = ""
+if config("ADMIN_URL_PREFIX", default = ""):
+    ADMIN_URL_PREFIX = config("ADMIN_URL_PREFIX")

--- a/yata/urls.py
+++ b/yata/urls.py
@@ -47,7 +47,7 @@ urlpatterns = [
     re_path(r'^setup/', include('setup.urls')),
     re_path(r'^api/', include('api.urls')),
     re_path(r'^company/', include('company.urls')),
-    path(f'{settings.ADMIN_URL_HASH}/admin/', admin.site.urls),
+    path(f'{settings.ADMIN_URL_PREFIX}admin', admin.site.urls),
 
     # site
     path('', views.index, name="index"),

--- a/yata/urls.py
+++ b/yata/urls.py
@@ -18,7 +18,7 @@ from django.contrib import admin
 from django.http import HttpResponse
 from django.views.generic.base import RedirectView
 
-# for media
+# for media and admin url obfuscation
 from django.conf import settings
 from django.conf.urls.static import static
 
@@ -47,7 +47,7 @@ urlpatterns = [
     re_path(r'^setup/', include('setup.urls')),
     re_path(r'^api/', include('api.urls')),
     re_path(r'^company/', include('company.urls')),
-    path('admin/', admin.site.urls),
+    path(f'{settings.ADMIN_URL_HASH}/admin/', admin.site.urls),
 
     # site
     path('', views.index, name="index"),


### PR DESCRIPTION
Please make sure you run the project first, check the admin link appears reasonably well, and that the link takes you to the admin index page. This will only show for superusers