### PR TITLE
fix add target button off screen

### DIFF
--- a/templates/faction/war/index.html
+++ b/templates/faction/war/index.html
@@ -56,9 +56,6 @@ This file is part of yata.
     <div class="d-flex flex-wrap align-items-center">
         <div class="px-2 me-auto"><i class="fas fa-crosshairs"></i>&nbsp;Target list</div>
         <div class="px-2">
-            <a id="targets-update" href=""><i class="fas fa-crosshairs fa-icon-inline" title="Add to targets list"></i>&nbsp;Update targets</a>
-        </div>
-        <div class="px-2">
             <a id="faction-targets-refresh" href=""><i class="fas fa-sync fa-icon-inline" title="Refresh targets"></i>&nbsp;Refresh</a>
         </div>
     </div>

--- a/templates/faction/war/targets.html
+++ b/templates/faction/war/targets.html
@@ -106,7 +106,7 @@ This file is part of yata.
                   <th class="f" title="Status of the target">Status</th>
                   <th class="g" title="Time since last update">Update</th>
                   <th class="h" title="Call dibs">Dibs</th>
-                  <th class="i" style="width: 2.5vw;" title="Add target">Save</th>
+                  <th class="h" title="Add target">Save</th>
           </thead>
           <tbody>
           {% for target in targets %}


### PR DESCRIPTION
also removes unused ui element from adding rw targets to personal targets
![image](https://github.com/Kivou-2000607/yata/assets/165085079/1f0b805f-13a1-4dc9-9876-5f819f963bd4)

![image](https://github.com/Kivou-2000607/yata/assets/165085079/16309719-5166-4405-928b-c971624cf83a)
