### PR TITLE
Fix sorting by NNB

### DIFF
--- a/templates/faction/members/line.html
+++ b/templates/faction/members/line.html
@@ -44,7 +44,7 @@ This file is part of yata.
     {% if member.shareE < 0 %}
       <td class="text-center" colspan="4"><span class="error" title="{{member.name}} is not on YATA"><i class="fas fa-user-slash"></i></span></td>
     {% else %}
-      <td class="text-end{% if member.tId == player.tId %} dont-touch-me{% endif %}" data-val="{%if member.shareN > 0%}{{member.crimesRank}}{%endif%}">
+      <td class="text-end{% if member.tId == player.tId %} dont-touch-me{% endif %}" data-val="{%if member.shareN > 0%}{{member.nnb}}{%endif%}">
         {% include "faction/members/nnb.html"%}
       </td>
       <td class="text-center{% if member.tId == player.tId %} dont-touch-me{% endif %}" data-val="{%if member.shareE > 0%}{{member.energy}}{%endif%}">


### PR DESCRIPTION
https://yata.yt/faction/members/


The data-val is being set as the CE value instead of the NNB value which results in 
```html
<td class="text-center" data-val="37">#37</td>
<td class="text-end" data-val="37">
      <span title="65 NNB">65</span>
</td>
```

And weird sorting because it just uses the CE value instead.
<img width="152" height="219" alt="image" src="https://github.com/user-attachments/assets/f2870daa-246e-46f9-9aa2-ee44d560a427" />