### PR TITLE
Fix typo: "Mechanical guns" -> "Mechanical weapons" in War Machine award

### DIFF
--- a/awards/functions.py
+++ b/awards/functions.py
@@ -755,7 +755,7 @@ def createAwards(tornAwards, userInfo, category, pinned=False):
                     nHits = int(v["description"].split(" ")[1].replace(",", ""))
                     bridge = {
                         "heahits": ["Heavy artillery", 0, ""],
-                        "chahits": ["Mechanical guns", 0, ""],
+                        "chahits": ["Mechanical weapons", 0, ""],
                         "axehits": ["Clubbing weapons", 0, ""],
                         "grehits": ["Temporary weapons", 0, ""],
                         "machits": ["Machine guns", 0, ""],


### PR DESCRIPTION
## Summary
- The "War Machine" award tracker (`awards/functions.py`) labeled the mechanical weapons category as "Mechanical guns" instead of "Mechanical weapons"
- Updated the label to match the correct weapon type name
